### PR TITLE
Fix header logo overlapping title text

### DIFF
--- a/app.py
+++ b/app.py
@@ -211,7 +211,8 @@ def header_bar():
         with c1:
             logo = _logo_path("dark_logo")
             if logo:
-                st.image(str(logo), width=140)
+                # Scale the logo to the column width so it doesn't overlap text
+                st.image(str(logo), use_column_width=True)
             else:
                 st.markdown("### NVision")  # fallback text logo
         with c2:


### PR DESCRIPTION
## Summary
- Scale header logo to the column width to keep it from covering page text

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f59f65420833198cddbd9b10467fd