### PR TITLE
Hide Streamlit menu and footer

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,6 +20,16 @@ st.set_page_config(
     initial_sidebar_state="expanded",
 )
 
+# Hide Streamlit's default menu and footer
+HIDE_STREAMLIT_STYLE = """
+    <style>
+        #MainMenu {visibility: hidden;}
+        header {visibility: hidden;}
+        footer {visibility: hidden;}
+    </style>
+"""
+st.markdown(HIDE_STREAMLIT_STYLE, unsafe_allow_html=True)
+
 # ---------- Enhanced UI polish with MSU theme ----------
 st.markdown(
     """


### PR DESCRIPTION
## Summary
- hide Streamlit's default main menu and footer for a cleaner interface

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f736fadb88331ad6b3638f29890b7