### PR TITLE
Fix net worth chart and add cash flow and tax charts

### DIFF
--- a/retirement_planner/components/charts.py
+++ b/retirement_planner/components/charts.py
@@ -78,6 +78,48 @@ def account_area_chart(ages, series_dict, title="Account Balances (Median Path)"
     return fig
 
 
+# ---------- Cash flow line chart ----------
+def cash_flow_chart(
+    ages: Sequence[int],
+    income: Sequence[float],
+    expenses: Sequence[float],
+    title: str = "Income vs Expenses",
+) -> go.Figure:
+    """Line chart comparing annual income and expenses."""
+    n = len(ages)
+    inc = _fit(income, n)
+    exp = _fit(expenses, n)
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scatter(
+            x=ages,
+            y=inc,
+            mode="lines",
+            name="Income",
+            hovertemplate="Age %{x}<br>$%{y:,.0f}<extra></extra>",
+        )
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=ages,
+            y=exp,
+            mode="lines",
+            name="Expenses",
+            hovertemplate="Age %{x}<br>$%{y:,.0f}<extra></extra>",
+        )
+    )
+    fig.update_layout(
+        title=title,
+        template="plotly_white",
+        height=380,
+        margin=dict(l=10, r=10, t=40, b=10),
+        xaxis_title="Age",
+        yaxis_title="Dollars (nominal)",
+        legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+    )
+    return fig
+
+
 # ---------- Success gauge ----------
 def success_gauge(success_prob: float) -> go.Figure:
     pct = max(0.0, min(100.0, float(success_prob) * 100.0))  # clamp 0–100


### PR DESCRIPTION
## Summary
- Handle updated Monte Carlo percentile output to restore net worth chart
- Add annual cash flow line chart
- Display yearly federal taxes from median ledger

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f78f1bca08331abf556b43c5a7a54