### PR TITLE
Fix resetting load selection to prevent Streamlit session state error

### DIFF
--- a/app.py
+++ b/app.py
@@ -399,7 +399,7 @@ with c2:
                 st.session_state["form_defaults"] = deepcopy(s["plan"])
                 st.session_state["plan"] = deepcopy(s["plan"])
                 st.session_state["special_editor_rows"] = s["plan"].get("expenses", {}).get("special", [])
-                st.session_state["load_select"] = ""  # reset selection to prevent rerun loop
+                st.session_state.pop("load_select", None)  # reset selection to prevent rerun loop
                 st.sidebar.success(f"Loaded '{load_name}'")
                 st.rerun()
 


### PR DESCRIPTION
## Summary
- Reset saved-scenario selector by removing its session state key after load

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4d9a6fd44833196b21c0d4ec9142e