### PR TITLE
Estimate Social Security PIA from projected earnings

### DIFF
--- a/retirement_planner/components/forms.py
+++ b/retirement_planner/components/forms.py
@@ -1,4 +1,5 @@
 import streamlit as st
+from retirement_planner.calculators.social_security import estimate_pia
 
 # Stable widget keys so we can programmatically set values on load
 WIDGET_KEYS = {
@@ -186,10 +187,14 @@ def plan_form():
 
     # -------- Social Security --------
     st.sidebar.header("Social Security")
+    estimated_pia = estimate_pia(current_age, retire_age, salary, salary_growth_pct / 100.0)
     ss_pia = st.sidebar.number_input(
         "PIA (monthly at FRA)", min_value=0.0,
-        value=_d("ss_pia", 0.0), key=WIDGET_KEYS["ss_pia"],
+        value=_d("ss_pia", estimated_pia), key=WIDGET_KEYS["ss_pia"],
         help="Primary Insurance Amount — benefit at full retirement age (67).",
+    )
+    st.sidebar.caption(
+        "PIA estimated from projected earnings; override if you have an official SSA statement."
     )
     ss_claim_age = st.sidebar.number_input(
         "Claiming age", min_value=62, max_value=70,

--- a/tests/test_social_security.py
+++ b/tests/test_social_security.py
@@ -26,3 +26,9 @@ def test_survivor_benefit():
     # The survivor should receive 1500*12
     survivor = ss.social_security_benefit(PIA=1500, start_age=67, spouse_PIA=1000, spouse_start_age=67, survivor=True)
     assert math.isclose(survivor, 1500 * 12, rel_tol=1e-4)
+
+
+def test_estimate_pia_constant_salary():
+    """Estimating PIA from a flat salary reproduces the formula."""
+    pia = ss.estimate_pia(current_age=30, retire_age=67, salary=60000, salary_growth=0.0)
+    assert math.isclose(pia, 2280.92, rel_tol=1e-4)


### PR DESCRIPTION
## Summary
- estimate Primary Insurance Amount (PIA) from projected salary history using SSA 2024 bend points
- pre-fill PIA field in the form and allow manual override with disclaimer
- cover new PIA estimator with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4e5b03c4883319dacc20f970f5786