### PR TITLE
Display present value metric and update visuals

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,9 +33,10 @@ from retirement_planner.components.insights import generate_insights
 
 
 # ---------- Page config ----------
+ICON_PATH = Path(__file__).resolve().parent / "assets" / "light_logo.png"
 st.set_page_config(
     page_title="NVision Retirement Simulator",
-    page_icon="📈",
+    page_icon=str(ICON_PATH),
     layout="wide",
     initial_sidebar_state="expanded",
 )
@@ -168,6 +169,7 @@ st.session_state.setdefault("chart_figs", {})
 BASE_DIR = Path(__file__).resolve().parent
 DATA_DIR = BASE_DIR / "retirement_planner" / "data"
 USERS_PATH = DATA_DIR / "users.json"
+DISCOUNT_RATE = 0.03  # annual discount rate for present value
 
 def _read_users():
     try:
@@ -480,8 +482,20 @@ with kcol1:
     st.plotly_chart(fig_success, use_container_width=True)
 
 with kcol2:
-    st.metric(label="Median terminal net worth", value=f"${results['median_terminal']:,.0f}")
-    st.caption("Median of ending net worth across all Monte Carlo paths.")
+    col_fv, col_pv = st.columns(2)
+    col_fv.metric(
+        label="Median terminal net worth",
+        value=f"${results['median_terminal']:,.0f}"
+    )
+    years = plan["end_age"] - plan["current_age"]
+    npv_terminal = results["median_terminal"] / ((1 + DISCOUNT_RATE) ** years)
+    col_pv.metric(
+        label="Present value",
+        value=f"${npv_terminal:,.0f}"
+    )
+    st.caption(
+        f"Median of ending net worth across all Monte Carlo paths. Present value discounted at {DISCOUNT_RATE*100:.1f}% per year."
+    )
 
 with kcol2:
     st.metric(label="Simulation size", value=f"{n_paths:,} paths")

--- a/retirement_planner/components/charts.py
+++ b/retirement_planner/components/charts.py
@@ -78,34 +78,35 @@ def account_area_chart(ages, series_dict, title="Account Balances (Median Path)"
     return fig
 
 
-# ---------- Cash flow line chart ----------
+# ---------- Cash flow bar chart ----------
 def cash_flow_chart(
     ages: Sequence[int],
     income: Sequence[float],
     expenses: Sequence[float],
     title: str = "Income vs Expenses",
 ) -> go.Figure:
-    """Line chart comparing annual income and expenses."""
+    """Bar chart showing income (green) above and expenses (red) below zero."""
     n = len(ages)
     inc = _fit(income, n)
     exp = _fit(expenses, n)
     fig = go.Figure()
     fig.add_trace(
-        go.Scatter(
+        go.Bar(
             x=ages,
             y=inc,
-            mode="lines",
             name="Income",
+            marker_color="#22c55e",
             hovertemplate="Age %{x}<br>$%{y:,.0f}<extra></extra>",
         )
     )
     fig.add_trace(
-        go.Scatter(
+        go.Bar(
             x=ages,
-            y=exp,
-            mode="lines",
+            y=[-e for e in exp],
             name="Expenses",
-            hovertemplate="Age %{x}<br>$%{y:,.0f}<extra></extra>",
+            marker_color="#ef4444",
+            customdata=exp,
+            hovertemplate="Age %{x}<br>$%{customdata:,.0f}<extra></extra>",
         )
     )
     fig.update_layout(
@@ -115,6 +116,7 @@ def cash_flow_chart(
         margin=dict(l=10, r=10, t=40, b=10),
         xaxis_title="Age",
         yaxis_title="Dollars (nominal)",
+        barmode="relative",
         legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
     )
     return fig


### PR DESCRIPTION
## Summary
- Use company logo as page favicon
- Show present value of terminal net worth next to future value
- Render income and expenses as green/red bars around zero

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4ec94d42c83318e395ca6c4930b2e