### PR TITLE
Fix scenario load defaults and show detailed taxes

### DIFF
--- a/tests/test_capital_gains_state_tax.py
+++ b/tests/test_capital_gains_state_tax.py
@@ -26,6 +26,9 @@ def test_capital_gains_and_state_tax_applied():
 
     # Expected taxes: capital gains tax on $50k gain (446.25) + MI state tax (~2017.85)
     assert ledger["taxes"][0] == pytest.approx(2464.1, rel=1e-3)
+    assert ledger["tax_cap_gains"][0] == pytest.approx(446.25, rel=1e-3)
+    assert ledger["tax_state"][0] == pytest.approx(2017.85, rel=1e-3)
+    assert ledger["tax_ordinary"][0] == pytest.approx(0.0, rel=1e-3)
     # Remaining taxable balance after covering expenses and taxes
     assert ledger["taxable"][0] == pytest.approx(47535.9, rel=1e-3)
 


### PR DESCRIPTION
## Summary
- populate sidebar inputs when loading scenarios by flattening saved plans
- expand Monte Carlo ledger with ordinary, capital-gains and state tax totals
- display state and capital-gains in the taxes chart

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b84b27b20483319d6cf27997aebff2